### PR TITLE
Rocksprings mining ruins 

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -297,7 +297,7 @@
 /turf/closed/wall/f13/wood/house{
 	icon_state = "house1"
 	},
-/area/f13/caves)
+/area/f13/building)
 "amp" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/metal{
@@ -1089,7 +1089,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "bbp" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -2843,7 +2843,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "cHb" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/wasteland{
@@ -5147,11 +5147,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/rocksprings)
-"eQu" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/wasteland/rocksprings)
 "eRn" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -6509,7 +6504,7 @@
 	color = "#845f58"
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "gld" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -6556,11 +6551,6 @@
 /obj/structure/safe/floor,
 /turf/open/floor/carpet,
 /area/f13/building)
-"gmC" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood1-broken"
-	},
-/area/f13/wasteland/rocksprings)
 "gmP" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -6673,7 +6663,7 @@
 /turf/closed/wall/f13/wood/house{
 	icon_state = "house3"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "gsA" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/savannah{
@@ -7744,8 +7734,10 @@
 /obj/item/grenade/f13/dynamite,
 /obj/item/mining_scanner,
 /obj/item/pickaxe,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/storage/bag/ore,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hvl" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -8094,7 +8086,7 @@
 "hQp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hQu" = (
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16122,7 +16114,7 @@
 /turf/closed/wall/f13/wood/house{
 	icon_state = "house2-broken"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "pMj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -16901,10 +16893,6 @@
 	name = "stone tile"
 	},
 /area/f13/caves)
-"qyX" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
 "qyY" = (
 /obj/item/defibrillator/primitive,
 /obj/effect/decal/cleanable/dirt,
@@ -17474,9 +17462,6 @@
 	},
 /obj/structure/flora/tree/jungle,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/rocksprings)
-"rcu" = (
-/turf/open/floor/f13/wood,
 /area/f13/wasteland/rocksprings)
 "rcx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24886,7 +24871,7 @@
 /turf/closed/wall/f13/wood/house{
 	icon_state = "house2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "yej" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/effect/decal/cleanable/dirt,
@@ -84377,8 +84362,8 @@ hgP
 hgP
 gkC
 baZ
-rcu
-eQu
+coX
+gJl
 lOb
 duT
 rPW
@@ -84632,7 +84617,7 @@ hgP
 sJx
 hgP
 hgP
-glr
+oXV
 hvg
 hQp
 hQp
@@ -84889,10 +84874,10 @@ hgP
 tWE
 hgP
 wxj
-qyX
+wkl
 hQp
-gmC
-rcu
+hFX
+coX
 xhn
 faW
 iTx
@@ -85146,9 +85131,9 @@ hgP
 sJx
 hgP
 hgP
-glr
+oXV
 cGZ
-rcu
+coX
 hQp
 cCp
 gYt

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -293,6 +293,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/rocksprings)
+"ama" = (
+/turf/closed/wall/f13/wood/house{
+	icon_state = "house1"
+	},
+/area/f13/caves)
 "amp" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/metal{
@@ -1077,6 +1082,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
+	},
+/area/f13/wasteland/rocksprings)
+"baZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
 /area/f13/wasteland/rocksprings)
 "bbp" = (
@@ -2706,6 +2717,14 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/rocksprings)
+"cCp" = (
+/obj/item/stack/ore/titanium,
+/obj/item/stack/ore/titanium,
+/obj/item/stack/ore/titanium,
+/obj/item/stack/ore/titanium,
+/obj/item/stack/ore/titanium,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cCx" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -2820,6 +2839,11 @@
 	icon_state = "savannah2"
 	},
 /area/f13/building)
+"cGZ" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland/rocksprings)
 "cHb" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/wasteland{
@@ -3395,6 +3419,10 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/rocksprings)
+"did" = (
+/obj/structure/tires,
+/turf/open/indestructible/ground/outside/desert/harsh,
+/area/f13/wasteland/rocksprings)
 "dio" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
@@ -3622,6 +3650,10 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/rocksprings)
+"duT" = (
+/obj/structure/ore_box,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dvr" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -4856,6 +4888,12 @@
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
+"eDj" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert/harsh,
+/area/f13/wasteland/rocksprings)
 "eDC" = (
 /obj/structure/fence/corner{
 	dir = 5
@@ -5109,6 +5147,11 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/rocksprings)
+"eQu" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/wasteland/rocksprings)
 "eRn" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -5284,6 +5327,10 @@
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/bar,
 /area/f13/building)
+"faW" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fba" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -5842,6 +5889,12 @@
 	pixel_y = -9
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/rocksprings)
+"fCr" = (
+/obj/structure/car/rubbish1{
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland/rocksprings)
 "fCY" = (
 /obj/structure/table/wood,
@@ -6450,6 +6503,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/building)
+"gkC" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/wasteland/rocksprings)
 "gld" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -6496,6 +6556,11 @@
 /obj/structure/safe/floor,
 /turf/open/floor/carpet,
 /area/f13/building)
+"gmC" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/wasteland/rocksprings)
 "gmP" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -6504,6 +6569,10 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
+/area/f13/wasteland/rocksprings)
+"gmS" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland/rocksprings)
 "gnc" = (
 /obj/effect/decal/riverbank{
@@ -6599,6 +6668,11 @@
 "gsd" = (
 /obj/structure/girder/displaced,
 /turf/open/indestructible/ground/outside/desert/harsh,
+/area/f13/wasteland/rocksprings)
+"gsk" = (
+/turf/closed/wall/f13/wood/house{
+	icon_state = "house3"
+	},
 /area/f13/wasteland/rocksprings)
 "gsA" = (
 /obj/structure/fence/wooden,
@@ -7218,6 +7292,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/rocksprings)
+"gYt" = (
+/obj/item/trash/f13/porknbeans,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gYS" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/toolsbasic,
@@ -7661,6 +7739,13 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
+"hvg" = (
+/obj/structure/shelf_wood,
+/obj/item/grenade/f13/dynamite,
+/obj/item/mining_scanner,
+/obj/item/pickaxe,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland/rocksprings)
 "hvl" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -8006,6 +8091,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hQp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland/rocksprings)
 "hQu" = (
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9048,6 +9137,11 @@
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/building)
+"iTx" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "iUa" = (
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
@@ -9775,6 +9869,11 @@
 "jLa" = (
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/legion)
+"jLb" = (
+/obj/structure/bed/old,
+/obj/effect/spawner/lootdrop/weapons/hunting,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jLk" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 4
@@ -14748,6 +14847,14 @@
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland/rocksprings)
+"oAD" = (
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oAV" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 8
@@ -16011,6 +16118,11 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/rocksprings)
+"pLz" = (
+/turf/closed/wall/f13/wood/house{
+	icon_state = "house2-broken"
+	},
+/area/f13/wasteland/rocksprings)
 "pMj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -16789,6 +16901,10 @@
 	name = "stone tile"
 	},
 /area/f13/caves)
+"qyX" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland/rocksprings)
 "qyY" = (
 /obj/item/defibrillator/primitive,
 /obj/effect/decal/cleanable/dirt,
@@ -17358,6 +17474,9 @@
 	},
 /obj/structure/flora/tree/jungle,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/rocksprings)
+"rcu" = (
+/turf/open/floor/f13/wood,
 /area/f13/wasteland/rocksprings)
 "rcx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18227,6 +18346,10 @@
 	icon_state = "greenrusty"
 	},
 /area/f13/building)
+"rOZ" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/desert/harsh,
+/area/f13/wasteland/rocksprings)
 "rPW" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -20443,6 +20566,10 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building)
+"tWE" = (
+/obj/structure/fence/door,
+/turf/open/indestructible/ground/outside/desert/harsh,
+/area/f13/wasteland/rocksprings)
 "tWN" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8";
@@ -22654,6 +22781,12 @@
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland/rocksprings)
+"waX" = (
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert/harsh,
+/area/f13/wasteland/rocksprings)
 "wbz" = (
 /turf/open/floor/plasteel/f13{
 	dir = 4;
@@ -23090,6 +23223,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/caves)
+"wxj" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/indestructible/ground/outside/desert/harsh,
+/area/f13/wasteland/rocksprings)
 "wxt" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24743,6 +24880,11 @@
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland/rocksprings)
+"yeg" = (
+/turf/closed/wall/f13/wood/house{
+	icon_state = "house2"
 	},
 /area/f13/wasteland/rocksprings)
 "yej" = (
@@ -83716,11 +83858,11 @@ hgP
 hgP
 hgP
 hgP
-hgP
-hgP
-hgP
-hgP
-hgP
+waX
+eEc
+eEc
+eEc
+eEc
 rPW
 rPW
 rPW
@@ -83973,13 +84115,13 @@ hgP
 hgP
 hgP
 hgP
+sJx
 hgP
 hgP
-hgP
-hgP
-hgP
-hgP
-rPW
+yeg
+gsk
+gsk
+ama
 rPW
 rPW
 rPW
@@ -84230,15 +84372,15 @@ hgP
 hgP
 hgP
 hgP
+sJx
 hgP
 hgP
-hgP
-hgP
-hgP
-hgP
-hgP
-rPW
-rPW
+gkC
+baZ
+rcu
+eQu
+lOb
+duT
 rPW
 rPW
 rPW
@@ -84487,16 +84629,16 @@ hgP
 hgP
 hgP
 hgP
+sJx
 hgP
 hgP
-hgP
-hgP
-hgP
-hgP
-hgP
-rPW
-rPW
-rPW
+glr
+hvg
+hQp
+hQp
+lOb
+lOb
+oAD
 rPW
 rPW
 rPW
@@ -84744,17 +84886,17 @@ hgP
 nzH
 hgP
 hgP
+tWE
 hgP
-hgP
-hgP
-hgP
-hgP
-hgP
-hgP
-rPW
-rPW
-rPW
-rPW
+wxj
+qyX
+hQp
+gmC
+rcu
+xhn
+faW
+iTx
+jLb
 rPW
 rPW
 rPW
@@ -85001,15 +85143,15 @@ hgP
 hgP
 hgP
 hgP
+sJx
 hgP
 hgP
-hgP
-hgP
-hgP
-hgP
-hgP
-rPW
-rPW
+glr
+cGZ
+rcu
+hQp
+cCp
+gYt
 rPW
 rPW
 rPW
@@ -85258,13 +85400,13 @@ hgP
 hgP
 hgP
 hgP
+sJx
 hgP
 hgP
-hgP
-hgP
-hgP
-hgP
-rPW
+pLz
+gsk
+gsk
+ama
 rPW
 rPW
 rPW
@@ -85514,13 +85656,13 @@ hgP
 hgP
 hgP
 hgP
+fkx
+sJx
+hgP
+mWW
 hgP
 hgP
-hgP
-hgP
-hgP
-hgP
-hgP
+gmS
 rPW
 rPW
 rPW
@@ -85772,9 +85914,9 @@ hgP
 hgP
 hgP
 hgP
+fCr
 hgP
-hgP
-hgP
+rOZ
 hgP
 hgP
 rPW
@@ -86031,9 +86173,9 @@ hgP
 hgP
 hgP
 hgP
+eDj
 hgP
-hgP
-hgP
+did
 rPW
 rPW
 rPW
@@ -86286,8 +86428,8 @@ hgP
 hgP
 hgP
 hgP
-hgP
-hgP
+sJx
+did
 hgP
 hgP
 rPW
@@ -86543,7 +86685,7 @@ hgP
 hgP
 rTl
 hgP
-hgP
+sJx
 hgP
 hgP
 rPW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Adds a small mining ruin to the southeast of rocksprings, equipped with some basic mining supplies, populated with some radscorpions and now fixed to be correctly area-ed as a building.

![sjshehges](https://github.com/F13-Dusty-Trails/F13-Dusty-Trails/assets/163652192/2b29f22f-8313-47f7-a999-0b56682ee531)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's right next to some high chance ore spots and as it is rocksprings is rarely populated, I know it's likely going when the next map comes out but I'm mostly doing this for practice to help build my skills for mapping. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Mining ruin southeast rocksprings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
