### PR TITLE
Radio Fixes

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -5,7 +5,7 @@
 #define RADIO_CHANNEL_COMMON "Common"
 #define RADIO_KEY_COMMON ";"
 
-#define RADIO_CHANNEL_SECURITY "BDF"
+#define RADIO_CHANNEL_SECURITY "Waypoint Police"
 #define RADIO_KEY_SECURITY "s"
 #define RADIO_TOKEN_SECURITY ".s"
 
@@ -65,7 +65,7 @@
 #define RADIO_KEY_ENCLAVE "z"
 #define RADIO_TOKEN_ENCLAVE ".z"
 
-#define RADIO_CHANNEL_TOWN "Town"
+#define RADIO_CHANNEL_TOWN "Waypoint"
 #define RADIO_KEY_TOWN "f"
 #define RADIO_TOKEN_TOWN ".f"
 


### PR DESCRIPTION
## About The Pull Request
Another quick fix because I just realised this and it's a very easy one.

'Town' comms now show as Waypoint and the especially outdated 'BDF' now shows as Waypoint Police.
## Why It's Good For The Game
More lore friendly. Bighorn Defense Force is a relic.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog
:cl:
tweak: Changed some radio channel names.
/:cl: