### PR TITLE
Forge Priest Slight Buff

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -58,6 +58,9 @@ GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 /obj/item/stack/sheet/mineral/sandstone/thirty
 	amount = 30
 
+/obj/item/stack/sheet/mineral/sandstone/twenty
+	amount = 20
+
 /obj/item/stack/sheet/mineral/sandstone/twelve
 	amount = 12
 
@@ -303,6 +306,8 @@ GLOBAL_LIST_INIT(titanium_recipes, list ( \
 /obj/item/stack/sheet/mineral/titanium/fifty
 	amount = 50
 
+/obj/item/stack/sheet/mineral/titanium/fifteen
+	amount = 15
 
 /*
  * Plastitanium

--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -448,6 +448,9 @@ Mayor
 		/obj/item/clothing/neck/apron/labor/forge/khan = 1,
 		/obj/item/storage/belt/utility/artisan/full = 1,
 		/obj/item/clothing/glasses/welding = 1,
+		/obj/item/stack/sheet/metal/fifty = 1,
+		/obj/item/stack/sheet/mineral/sandstone/twenty = 1,
+		/obj/item/stack/sheet/mineral/titanium/fifteen = 1,
 		/obj/item/book/granter/trait/techno = 1
 	) // No weapons, you should be crafting them or using your null rod.
 


### PR DESCRIPTION
-Gave the forge priest the starting material to make an anvil and furnace at round start, given its a unique job unlike salvager. This makes forge priest slightly more enticing.

A request from someone who pointed out that forge priest really got the raw end of the deal compared to the others.

- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
