### PR TITLE
Hydra's recipe change.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -125,7 +125,7 @@
 /datum/crafting_recipe/hydra
 	name = "Hydra"
 	result = /obj/item/reagent_containers/pill/patch/hydra
-	reqs = list(/obj/item/reagent_containers/food/snacks/meat/slab/radscorpion_meat = 2,
+	reqs = list(/obj/item/reagent_containers/food/snacks/meat/slab/cazador_meat = 1,
 				/obj/item/reagent_containers/food/snacks/grown/fungus = 2)
 	time = 15
 	category = CAT_MEDICAL

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -114,7 +114,7 @@
 
 /obj/item/reagent_containers/pill/patch/hydra
 	name = "Hydra"
-	desc = "A fruit drink bottle with three sealed glass vials taped around the middle. It is filled with Hydra, a powerful wound-mending agent, derived from venomous radscorpion glands."
+	desc = "A fruit drink bottle with three sealed glass vials taped around the middle. It is filled with Hydra, a powerful wound-mending agent, derived from venomous cazador glands."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_hydra"
 	list_reagents = list(/datum/reagent/medicine/hydra = 10)


### PR DESCRIPTION
## About The Pull Request

Replaces the need for radscorpion meat(because they became extinct in La Verkin) to craft Hydra with cazador meat instead.

## Why It's Good For The Game

RADSCORPIONS ARE EXTINCT.
HYDRA IS FUEL.
BADLANDS IS FULL...... OF CAZADORES?!

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
tweak: Cazador meat is needed to craft hydra instead of radscorpion one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
