### PR TITLE
Changes the spatha's smithing step.

### DIFF
--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -36,7 +36,7 @@
 //Legion specific
 #define RECIPE_LANCE "ddbs" //draw draw bend shrink
 #define RECIPE_GLADIUS "ddp" //draw draw punch
-#define RECIPE_SPATHA "fduf" // fold draw upset fold
+#define RECIPE_SPATHA "ffuf" // fold fold upset fold
 #define RECIPE_WARHONED "udsb" //upset draw shrink bend
 
 // Armor


### PR DESCRIPTION
## About The Pull Request

The spatha now has similar smithing steps than longsword but with "upset" instead of "draw".

Fold Fold Upset Fold

## Why It's Good For The Game

Adding the tableanvilg shit to all anvils broke the spatha's crafting steps, I hope this fixes a bit the problem. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
fix: The spatha is now craftable again with a different smithing step: Fold, Fold Upset and Fold.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
